### PR TITLE
Add CLI tool for upload

### DIFF
--- a/cli/upload.js
+++ b/cli/upload.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+'use strict'
+
+const path = require('path')
+const ora = require('ora')
+const execa = require('execa')
+
+const pkg = require('../package')
+
+const macCLI = '/Applications/wechatwebdevtools.app/Contents/Resources/app.nw/bin/cli'
+const {version} = pkg
+const xiaofanPath = path.join(__dirname, '../sc')
+
+process.spinner = ora('Uploading...').start()
+
+const run = async () => {
+  try {
+    const {stdout} = await execa(macCLI, ['-u', `${version}@${xiaofanPath}`], {timeout: 10000})
+    if (stdout.match('upload success')) {
+      process.spinner.succeed('上传成功！')
+      process.exit()
+    }
+    process.spinner.fail('上传超时！')
+    process.exit()
+  } catch (err) {
+    const match = err.message.match(/error: '{"code":\d+,"error":"(.+)"}',/)
+    const message = match[1]
+    process.spinner.fail(message + '！')
+    process.exit()
+  }
+}
+
+run()

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fanfou WeApp",
   "main": "app.js",
   "scripts": {
-    "test": "xo"
+    "test": "xo",
+    "upload": "cli/upload.js"
   },
   "repository": {
     "type": "git",
@@ -55,5 +56,9 @@
     },
     "semicolon": false,
     "space": 2
+  },
+  "dependencies": {
+    "execa": "^0.8.0",
+    "ora": "^1.3.0"
   }
 }


### PR DESCRIPTION
### Requirement

- [WeApp DevTool on macOS](https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/download.html)

### Usage

```bash
# Clone this project
$ git clone https://github.com/fanfoujs/xiaofan.git

# Go to project directory d install dependencies
$ cd xiaofan
$ npm install

# Make sure your `src/project.config.json` exists.
# Let's upload it!
$ npm run upload

# Done!
```

### Documentation: CLI in WeApp DevTool

https://mp.weixin.qq.com/debug/wxadoc/dev/devtools/cli.html
